### PR TITLE
feat(franka-sim): Add controller type to training configuration

### DIFF
--- a/examples/experiments/config.py
+++ b/examples/experiments/config.py
@@ -1,8 +1,12 @@
 from abc import abstractmethod
 from typing import List
+from franka_env.envs.wrappers import (
+    ControllerType
+)
 
 class DefaultTrainingConfig:
     """Default training configuration. """
+    controller_type: ControllerType = ControllerType.XBOX
 
     agent: str = "drq"
     max_traj_length: int = 100

--- a/examples/experiments/pick_cube_sim/config.py
+++ b/examples/experiments/pick_cube_sim/config.py
@@ -9,7 +9,8 @@ from franka_env.envs.wrappers import (
     JoystickIntervention,
     MultiCameraBinaryRewardClassifierWrapper,
     GripperPenaltyWrapper,
-    GripperCloseEnv
+    GripperCloseEnv,
+    ControllerType
 )
 from franka_env.envs.relative_env import RelativeFrame
 from serl_launcher.wrappers.serl_obs_wrappers import SERLObsWrapper
@@ -21,6 +22,7 @@ from franka_sim.envs.panda_pick_gym_env import PandaPickCubeGymEnv
 
 
 class TrainConfig(DefaultTrainingConfig):
+    controller_type = ControllerType.PS5
     image_keys = ["front", "wrist"]
     classifier_keys = ["front", "wrist"]
     proprio_keys = ["tcp_pose", "tcp_vel", "gripper_pose"]
@@ -38,7 +40,7 @@ class TrainConfig(DefaultTrainingConfig):
     def get_environment(self, fake_env=False, save_video=False, classifier=False):
         env = PandaPickCubeGymEnv(render_mode="human", image_obs=True, time_limit=100.0, control_dt=0.1)
         if not fake_env:
-            env = JoystickIntervention(env)
+            env = JoystickIntervention(env=env, controller_type=self.controller_type)
         env = RelativeFrame(env)
         env = Quat2EulerWrapper(env)
         env = SERLObsWrapper(env, proprio_keys=self.proprio_keys)

--- a/examples/experiments/pick_cube_sim/config.py
+++ b/examples/experiments/pick_cube_sim/config.py
@@ -22,7 +22,7 @@ from franka_sim.envs.panda_pick_gym_env import PandaPickCubeGymEnv
 
 
 class TrainConfig(DefaultTrainingConfig):
-    controller_type = ControllerType.PS5
+    controller_type = ControllerType.XBOX
     image_keys = ["front", "wrist"]
     classifier_keys = ["front", "wrist"]
     proprio_keys = ["tcp_pose", "tcp_vel", "gripper_pose"]

--- a/examples/record_demos_sim.py
+++ b/examples/record_demos_sim.py
@@ -42,6 +42,7 @@ def main(_):
     trajectory = []
     returns = 0
     
+    print("Press shift to start recording.\nIf your controller is not working check controller_type (default is xbox) is configured in examples/experiments/pick_cube_sim/config.py")
     with mujoco.viewer.launch_passive(env.model, env.data) as viewer:
         while viewer.is_running():
             if start_key:

--- a/examples/record_success_fail_sim.py
+++ b/examples/record_success_fail_sim.py
@@ -43,8 +43,10 @@ def main(_):
     success_needed = FLAGS.successes_needed
     pbar = tqdm(total=success_needed)
     
+    print("Press shift to start recording, press enter to record a successful transition.\nIf your controller is not working check controller_type (default is xbox) is configured in examples/experiments/pick_cube_sim/config.py")
     with mujoco.viewer.launch_passive(env.model, env.data) as viewer:
         while viewer.is_running():
+            
             if start_key:
                 actions = np.zeros(env.action_space.sample().shape) 
                 next_obs, rew, done, truncated, info = env.step(actions)

--- a/franka_sim/README.md
+++ b/franka_sim/README.md
@@ -14,7 +14,10 @@ It includes a state-based and a vision-based Franka lift cube task environment.
 # Run Experiments
 - Run `python examples/experiments/record_success_fail_sim.py` to record success and failure trajectories which is used for training the reward model. Controller type can be set in `examples/experiments/pick_cube_sim/config.py`.
 - Run `python examples/experiments/record_demos_sim.py` to record demonstrations for training the policy. Controller type can be set in `examples/experiments/pick_cube_sim/config.py`.
-- Run `bash examples/experiments/pick_cube_sim/run_actor.sh` and `bash examples/experiments/pick_cube_sim/run_learner.sh` to train a rlpd agent to solve the pick cube task.
+- To train a rlpd agent to solve the pick cube task:
+    - `cd examples/experiments/pick_cube_sim` 
+    - run `bash run_actor.sh`
+    - run `bash run_learner.sh`
 
 # Credits:
 - This simulation is initially built by [Kevin Zakka](https://kzakka.com/).

--- a/franka_sim/README.md
+++ b/franka_sim/README.md
@@ -9,11 +9,11 @@ It includes a state-based and a vision-based Franka lift cube task environment.
 
 # Explore the Environments
 - Run `python franka_sim/test/test_gym_env_human.py` to launch a display window and visualize the task.
-- Run `python franka_sim/test/test_gym_env_joystick.py` to launch a display window and use joystick to control the arm.
+- Run `python franka_sim/test/test_gym_env_joystick.py` to launch a display window and use joystick to control the arm. Use `--controller` flag to set the controller type. e.g. `--controller ps5`. Default controller is xbox.
 
 # Run Experiments
-- Run `python examples/experiments/record_success_fail_sim.py` to record success and failure trajectories which is used for training the reward model.
-- Run `python examples/experiments/record_demos_sim.py` to record demonstrations for training the policy.
+- Run `python examples/experiments/record_success_fail_sim.py` to record success and failure trajectories which is used for training the reward model. Controller type can be set in `examples/experiments/pick_cube_sim/config.py`.
+- Run `python examples/experiments/record_demos_sim.py` to record demonstrations for training the policy. Controller type can be set in `examples/experiments/pick_cube_sim/config.py`.
 - Run `bash examples/experiments/pick_cube_sim/run_actor.sh` and `bash examples/experiments/pick_cube_sim/run_learner.sh` to train a rlpd agent to solve the pick cube task.
 
 # Credits:


### PR DESCRIPTION
# What this does
- Adds `controller_type` property to training config classes to support different kinds of controllers (xbox and ps5). xbox controller is default
- Updated `record_success_fail_sim.py` to print instruction to screen
- Updated `record_demos_sim.py` to print instruction to screen

# How was it tested
- Set `controller_type=ControllerType.PS5` in `examples/experiments/pick_cube_sim/config.py`
- Ran `python examples/experiments/record_success_fail_sim.py --exp_name pick_cube_sim` and confirm PS5 controller worked correctly
- Ran `python examples/experiments/record_demos_sim.py --exp_name pick_cube_sim` and confirm PS5 controller worked correctly