### PR TITLE
Add sparse reward and fix gripper penalty wrapper for pick_cube_sim

### DIFF
--- a/examples/experiments/pick_cube_sim/config.py
+++ b/examples/experiments/pick_cube_sim/config.py
@@ -8,10 +8,13 @@ from franka_env.envs.wrappers import (
     Quat2EulerWrapper,
     JoystickIntervention,
     MultiCameraBinaryRewardClassifierWrapper,
-    GripperPenaltyWrapper,
+    # GripperPenaltyWrapper,
     GripperCloseEnv,
     ControllerType
 )
+
+from experiments.pick_cube_sim.wrapper import GripperPenaltyWrapper
+
 from franka_env.envs.relative_env import RelativeFrame
 from serl_launcher.wrappers.serl_obs_wrappers import SERLObsWrapper
 from serl_launcher.wrappers.chunking import ChunkingWrapper

--- a/examples/experiments/pick_cube_sim/config.py
+++ b/examples/experiments/pick_cube_sim/config.py
@@ -8,7 +8,6 @@ from franka_env.envs.wrappers import (
     Quat2EulerWrapper,
     JoystickIntervention,
     MultiCameraBinaryRewardClassifierWrapper,
-    # GripperPenaltyWrapper,
     GripperCloseEnv,
     ControllerType
 )
@@ -41,7 +40,7 @@ class TrainConfig(DefaultTrainingConfig):
     classifier = False
 
     def get_environment(self, fake_env=False, save_video=False, classifier=False):
-        env = PandaPickCubeGymEnv(render_mode="human", image_obs=True, time_limit=100.0, control_dt=0.1)
+        env = PandaPickCubeGymEnv(render_mode="human", image_obs=True, reward_type="sparse", time_limit=100.0, control_dt=0.1)
         if not fake_env:
             env = JoystickIntervention(env=env, controller_type=self.controller_type)
         env = RelativeFrame(env)

--- a/examples/experiments/pick_cube_sim/run_actor.sh
+++ b/examples/experiments/pick_cube_sim/run_actor.sh
@@ -2,5 +2,5 @@ export XLA_PYTHON_CLIENT_PREALLOCATE=false && \
 export XLA_PYTHON_CLIENT_MEM_FRACTION=.1 && \
 python ../../train_rlpd_sim.py "$@" \
     --exp_name=pick_cube_sim \
-    --checkpoint_path=second_run \
+    --checkpoint_path=six_run \
     --actor \

--- a/examples/experiments/pick_cube_sim/run_learner.sh
+++ b/examples/experiments/pick_cube_sim/run_learner.sh
@@ -2,6 +2,6 @@ export XLA_PYTHON_CLIENT_PREALLOCATE=false && \
 export XLA_PYTHON_CLIENT_MEM_FRACTION=.3 && \
 python ../../train_rlpd_sim.py "$@" \
     --exp_name=pick_cube_sim \
-    --checkpoint_path=second_run \
-    --demo_path=../../demo_data/pick_cube_sim_30_demos_2024-11-28_19-58-59.pkl\
+    --checkpoint_path=six_run \
+    --demo_path=../../../demo_data/pick_cube_sim_30_demos_2025-01-22_11-04-51.pkl\
     --learner \

--- a/examples/experiments/pick_cube_sim/wrapper.py
+++ b/examples/experiments/pick_cube_sim/wrapper.py
@@ -1,0 +1,30 @@
+import gymnasium as gym
+
+
+class GripperPenaltyWrapper(gym.Wrapper):
+    def __init__(self, env, penalty=-0.05):
+        super().__init__(env)
+        assert env.action_space.shape == (7,)
+        self.penalty = penalty
+        self.last_gripper_pos = None
+
+    def reset(self, **kwargs):
+        obs, info = self.env.reset(**kwargs)
+        self.last_gripper_pos = obs["state"][0, 0]
+        return obs, info
+
+    def step(self, action):
+        """Modifies the :attr:`env` :meth:`step` reward using :meth:`self.reward`."""
+        observation, reward, terminated, truncated, info = self.env.step(action)
+        if "intervene_action" in info:
+            action = info["intervene_action"]
+
+        if (action[-1] < -0.5 and self.last_gripper_pos > 0.9) or (
+            action[-1] > 0.5 and self.last_gripper_pos < 0.9
+        ):
+            info["grasp_penalty"] = self.penalty
+        else:
+            info["grasp_penalty"] = 0.0
+
+        self.last_gripper_pos = observation["state"][0, 0]
+        return observation, reward, terminated, truncated, info

--- a/franka_sim/franka_sim/envs/panda_pick_gym_env.py
+++ b/franka_sim/franka_sim/envs/panda_pick_gym_env.py
@@ -137,14 +137,6 @@ class PandaPickCubeGymEnv(MujocoGymEnv):
             dtype=np.float32,
         )
 
-        # from gymnasium.envs.mujoco.mujoco_rendering import MujocoRenderer
-
-        # self._viewer = MujocoRenderer(
-        #     self.model,
-        #     self.data,
-        # )
-        # self._viewer.render(self.render_mode)
-
         self._viewer = mujoco.Renderer(
             self.model,
             height=render_spec.height,

--- a/franka_sim/franka_sim/envs/panda_pick_gym_env.py
+++ b/franka_sim/franka_sim/envs/panda_pick_gym_env.py
@@ -39,8 +39,10 @@ class PandaPickCubeGymEnv(MujocoGymEnv):
         render_spec: GymRenderingSpec = GymRenderingSpec(),
         render_mode: Literal["rgb_array", "human"] = "rgb_array",
         image_obs: bool = False,
+        reward_type: str = "sparse",
     ):
         self._action_scale = action_scale
+        self.reward_type = reward_type
 
         super().__init__(
             xml_path=_XML_PATH,
@@ -258,20 +260,20 @@ class PandaPickCubeGymEnv(MujocoGymEnv):
 
         return obs
 
-    # def _compute_reward(self) -> float:
-    #     block_pos = self._data.sensor("block_pos").data
-    #     tcp_pos = self._data.sensor("2f85/pinch_pos").data
-    #     dist = np.linalg.norm(block_pos - tcp_pos)
-    #     r_close = np.exp(-20 * dist)
-    #     r_lift = (block_pos[2] - self._z_init) / (self._z_success - self._z_init)
-    #     r_lift = np.clip(r_lift, 0.0, 1.0)
-    #     rew = 0.3 * r_close + 0.7 * r_lift
-    #     return rew
-    
     def _compute_reward(self) -> float:
-        block_pos = self._data.sensor("block_pos").data
-        lift = block_pos[2] - self._z_init
-        return float(lift > 0.2)
+        if self.reward_type == "dense":
+            block_pos = self._data.sensor("block_pos").data
+            tcp_pos = self._data.sensor("2f85/pinch_pos").data
+            dist = np.linalg.norm(block_pos - tcp_pos)
+            r_close = np.exp(-20 * dist)
+            r_lift = (block_pos[2] - self._z_init) / (self._z_success - self._z_init)
+            r_lift = np.clip(r_lift, 0.0, 1.0)
+            rew = 0.3 * r_close + 0.7 * r_lift
+            return rew
+        else:
+            block_pos = self._data.sensor("block_pos").data
+            lift = block_pos[2] - self._z_init
+            return float(lift > 0.2)
 
     def _is_success(self) -> bool:
         block_pos = self._data.sensor("block_pos").data

--- a/franka_sim/franka_sim/envs/panda_pick_gym_env.py
+++ b/franka_sim/franka_sim/envs/panda_pick_gym_env.py
@@ -31,7 +31,7 @@ class PandaPickCubeGymEnv(MujocoGymEnv):
 
     def __init__(
         self,
-        action_scale: np.ndarray = np.asarray([0.1, 1]),
+        action_scale: np.ndarray = np.asarray([0.05, 1]),
         seed: int = 0,
         control_dt: float = 0.02,
         physics_dt: float = 0.002,
@@ -230,24 +230,14 @@ class PandaPickCubeGymEnv(MujocoGymEnv):
         return obs, rew, terminated, False, {"succeed": success}
 
     def render(self):
-        self._viewer.render()
         rendered_frames = []
         for cam_id in self.camera_id:
             self._viewer.update_scene(self.data, camera=cam_id)
             rendered_frames.append(
                 self._viewer.render()
             )
-            self._viewer.render()
         return rendered_frames
 
-    # def render(self):
-    #     self._viewer.render(self.render_mode)
-    #     rendered_frames = []
-    #     for cam_id in self.camera_id:
-    #         rendered_frames.append(
-    #             self._viewer.render(render_mode="rgb_array", camera_id=cam_id)
-    #         )
-    #     return rendered_frames
 
     def _compute_observation(self) -> dict:
         obs = {}
@@ -276,16 +266,21 @@ class PandaPickCubeGymEnv(MujocoGymEnv):
 
         return obs
 
+    # def _compute_reward(self) -> float:
+    #     block_pos = self._data.sensor("block_pos").data
+    #     tcp_pos = self._data.sensor("2f85/pinch_pos").data
+    #     dist = np.linalg.norm(block_pos - tcp_pos)
+    #     r_close = np.exp(-20 * dist)
+    #     r_lift = (block_pos[2] - self._z_init) / (self._z_success - self._z_init)
+    #     r_lift = np.clip(r_lift, 0.0, 1.0)
+    #     rew = 0.3 * r_close + 0.7 * r_lift
+    #     return rew
+    
     def _compute_reward(self) -> float:
         block_pos = self._data.sensor("block_pos").data
-        tcp_pos = self._data.sensor("2f85/pinch_pos").data
-        dist = np.linalg.norm(block_pos - tcp_pos)
-        r_close = np.exp(-20 * dist)
-        r_lift = (block_pos[2] - self._z_init) / (self._z_success - self._z_init)
-        r_lift = np.clip(r_lift, 0.0, 1.0)
-        rew = 0.3 * r_close + 0.7 * r_lift
-        return rew
-    
+        lift = block_pos[2] - self._z_init
+        return float(lift > 0.2)
+
     def _is_success(self) -> bool:
         block_pos = self._data.sensor("block_pos").data
         tcp_pos = self._data.sensor("2f85/pinch_pos").data


### PR DESCRIPTION
# What this does:

1. Added gripper penalty wrapper to pick_cube_sim, matching usb_pickup_insertion implementation. This fixes a training issue where the policy avoided gripper state changes due to incorrect negative penalties.

2. Implemented optional sparse reward for pick_cube_sim alongside existing dense reward system.